### PR TITLE
Commented out ctypes.c_float_p casts

### DIFF
--- a/piggyphoto/__init__.py
+++ b/piggyphoto/__init__.py
@@ -652,7 +652,8 @@ class cameraWidget(object):
         if self.type in [GP_WIDGET_MENU, GP_WIDGET_RADIO, GP_WIDGET_TEXT]:
             value = ctypes.cast(value.value, ctypes.c_char_p)
         elif self.type == GP_WIDGET_RANGE:
-            value = ctypes.cast(value.value, ctypes.c_float_p)
+            #value = ctypes.cast(value.value, ctypes.c_float_p)
+            pass
         elif self.type in [GP_WIDGET_TOGGLE, GP_WIDGET_DATE]:
             #value = ctypes.cast(value.value, ctypes.c_int_p)
             pass
@@ -664,7 +665,8 @@ class cameraWidget(object):
         if self.type in (GP_WIDGET_MENU, GP_WIDGET_RADIO, GP_WIDGET_TEXT):
             value = ctypes.c_char_p(value)
         elif self.type == GP_WIDGET_RANGE:
-            value = ctypes.c_float_p(value) # this line not tested
+            #value = ctypes.c_float_p(value) # this line not tested
+            pass
         elif self.type in (GP_WIDGET_TOGGLE, GP_WIDGET_DATE):
             value = PTR(ctypes.c_int(value))
         else:


### PR DESCRIPTION
There is no such attribute for ctypes at least on Python 2.7 (current
Debian Squeeze version).
More over, Python ctypes documentation doesn't speak of this attribute:
http://docs.python.org/2/library/ctypes.html#fundamental-data-types

After some tests, it seems that this modification doesn't affect in a
bad maner the library.

Previous behavior:
Fails on main.actions.manualfocusdrive (value according to gphoto2
itself: 0)

Current behavior:
main.actions.manualfocusdrive = None

Tested with a Nikon d90.
